### PR TITLE
Added most frequent punctuation marks for ge'ez

### DIFF
--- a/src/geez_language_model.js
+++ b/src/geez_language_model.js
@@ -90,6 +90,6 @@ export default class GeezLanguageModel extends LanguageModel {
    * @returns {String} a string containing valid puncutation symbols
    */
   static getPunctuation () {
-    return "፡፨።,;:!?'\"(){}\\[\\]<>/\\\u00A0\u2010\u2011\u2012\u2013\u2014\u2015\u2018\u2019\u201C\u201D\u0387\u00B7\n\r"
+    return "፡፨።፣፤፥፦፧፠,;:!?'\"(){}\\[\\]<>/\\\u00A0\u2010\u2011\u2012\u2013\u2014\u2015\u2018\u2019\u201C\u201D\u0387\u00B7\n\r"
   }
 }

--- a/src/geez_language_model.js
+++ b/src/geez_language_model.js
@@ -90,6 +90,6 @@ export default class GeezLanguageModel extends LanguageModel {
    * @returns {String} a string containing valid puncutation symbols
    */
   static getPunctuation () {
-    return ".,;:!?'\"(){}\\[\\]<>/\\\u00A0\u2010\u2011\u2012\u2013\u2014\u2015\u2018\u2019\u201C\u201D\u0387\u00B7\n\r"
+    return "፡፨።,;:!?'\"(){}\\[\\]<>/\\\u00A0\u2010\u2011\u2012\u2013\u2014\u2015\u2018\u2019\u201C\u201D\u0387\u00B7\n\r"
   }
 }


### PR DESCRIPTION
፡is the OMNIPRESENT word separator. It can be preceded or followed by space or both, but is after every single word.
፨። are other punctuation marks